### PR TITLE
chromatic の GitHub Actions ワークフローに GITHUB_TOKEN の環境変数を追加

### DIFF
--- a/.github/workflows/chromatic-ui-test.yml
+++ b/.github/workflows/chromatic-ui-test.yml
@@ -11,4 +11,5 @@ jobs:
       - name: Publish to Chromatic
         uses: chromaui/action@v1
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}


### PR DESCRIPTION
なぜか毎回リトライしないと missing token のエラーが吐かれてしまったのを解消してみた。
シンプルに GITHUB_TOKEN を付与していなかっただけかもしれない
参考: https://www.chromatic.com/docs/github-actions#setup