### PR TITLE
Chromatic UI のトークン削除

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lint-staged": "lint-staged",
     "prepare": "husky install",
     "commitmsg": "commitlint -e $GIT_PARAMS",
-    "chromatic": "npx chromatic --project-token=89d2d6a5a458"
+    "chromatic": "npx chromatic --project-token=CHROMATIC_PROJECT_TOKEN"
   },
   "dependencies": {
     "@commitlint/cli": "^16.0.1",


### PR DESCRIPTION
package.json に生のトークンが表示されていたので削除 (トークンは再生成済み)